### PR TITLE
[CNDIT-911] Bug fixes in status and validate endpoint

### DIFF
--- a/src/main/java/gov/cdc/dataingestion/commands/Hl7Validation.java
+++ b/src/main/java/gov/cdc/dataingestion/commands/Hl7Validation.java
@@ -25,7 +25,7 @@ public class Hl7Validation extends PropUtil implements Runnable{
                 try(BufferedReader reader = new BufferedReader(new FileReader(hl7FilePath))) {
                     String line;
                     while((line = reader.readLine()) != null) {
-                        requestBody.append(line);
+                        requestBody.append(line + "\n");
                     }
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/gov/cdc/dataingestion/commands/ReportStatus.java
+++ b/src/main/java/gov/cdc/dataingestion/commands/ReportStatus.java
@@ -16,7 +16,7 @@ public class ReportStatus extends PropUtil implements Runnable{
     @Override
     @SuppressWarnings("java:S106")
     public void run() {
-        if(reportUuid != null) {
+        if(reportUuid != null && !reportUuid.isEmpty()) {
 
             // Serving data from INT1 environment as the production doesn't have data yet
             String serviceEndpoint = getProperty("service.env.url") + getProperty("service.env.reportStatusEndpoint");
@@ -27,7 +27,7 @@ public class ReportStatus extends PropUtil implements Runnable{
             System.out.println(apiResponse);
             }
         else {
-            System.err.println("Report UUID is null.");
+            System.err.println("Report UUID is null or empty.");
         }
     }
 }

--- a/src/main/java/gov/cdc/dataingestion/commands/TokenGenerator.java
+++ b/src/main/java/gov/cdc/dataingestion/commands/TokenGenerator.java
@@ -49,11 +49,11 @@ public class TokenGenerator extends PropUtil implements Runnable {
                 }
             }
             else {
-                System.err.println("Username or password is empty.");
+                System.err.println("Client Id or Secret is empty.");
             }
         }
         else {
-            System.err.println("Username or password is null.");
+            System.err.println("Client Id or Secret is null.");
         }
     }
 }

--- a/src/main/java/gov/cdc/dataingestion/util/AuthUtil.java
+++ b/src/main/java/gov/cdc/dataingestion/util/AuthUtil.java
@@ -52,12 +52,7 @@ public class AuthUtil {
     }
 
     private String getResultFromResponse(String name, CloseableHttpClient httpsClient, CloseableHttpResponse response, int statusCode) throws IOException {
-        if (statusCode == 200) {
-            InputStream content = response.getEntity().getContent();
-            String result = convertInputStreamToString(content);
-            httpsClient.close();
-            return result;
-        } else if (statusCode == 400) {
+        if (statusCode == 200 || statusCode == 400) {
             InputStream content = response.getEntity().getContent();
             String result = convertInputStreamToString(content);
             httpsClient.close();

--- a/src/main/java/gov/cdc/dataingestion/util/AuthUtil.java
+++ b/src/main/java/gov/cdc/dataingestion/util/AuthUtil.java
@@ -57,6 +57,11 @@ public class AuthUtil {
             String result = convertInputStreamToString(content);
             httpsClient.close();
             return result;
+        } else if (statusCode == 400) {
+            InputStream content = response.getEntity().getContent();
+            String result = convertInputStreamToString(content);
+            httpsClient.close();
+            return result;
         } else if (statusCode == 401) {
             httpsClient.close();
             return "Unauthorized: Your token may have expired. Please review and confirm your authentication settings.";

--- a/src/test/java/gov/cdc/dataingestion/commands/ReportStatusTest.java
+++ b/src/test/java/gov/cdc/dataingestion/commands/ReportStatusTest.java
@@ -65,7 +65,7 @@ class ReportStatusTest {
 
         reportStatus.run();
 
-        assertEquals("Report UUID is null.", errStream.toString().trim());
+        assertEquals("Report UUID is null or empty.", errStream.toString().trim());
     }
 
     @Test

--- a/src/test/java/gov/cdc/dataingestion/commands/TokenGeneratorTest.java
+++ b/src/test/java/gov/cdc/dataingestion/commands/TokenGeneratorTest.java
@@ -81,7 +81,7 @@ class TokenGeneratorTest {
     void testRunEmptyUsernameOrPassword() {
         String username = "";
         char[] password = "testUserPassword".toCharArray();
-        String expectedOutput = "Username or password is empty.";
+        String expectedOutput = "Client Id or Secret is empty.";
 
         tokenGenerator.clientId = username;
         tokenGenerator.clientSecret = password;
@@ -95,7 +95,7 @@ class TokenGeneratorTest {
     void testRunNullUsernameOrPassword() {
         String username = "testUser";
         char[] password = null;
-        String expectedOutput = "Username or password is null.";
+        String expectedOutput = "Client Id or Secret is null.";
 
         tokenGenerator.clientId = username;
         tokenGenerator.clientSecret = password;


### PR DESCRIPTION
This PR contains couple of bug fixes in the `status` and `validatehl7` endpoints.
- Fixing the error message to display something meaningful and fixing empty input.
- Fixing the validation failure for some HL7 files due to formatting issue.
- Adding one more error code to obtain the correct message from the service side.